### PR TITLE
Fix attachment name insertion

### DIFF
--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -15,7 +15,7 @@ async function loadPlayer() {
         m4aAttachments.push(attachment);
         
         const attachmentLi = document.createElement('li');
-        attachmentLi.innerHTML = attachment.name;
+        attachmentLi.textContent = attachment.name;
         attachmentLi.addEventListener('click', () => {
           loadAttachment(m4aAttachments.findIndex((att) => att.name == attachment.name));
         });


### PR DESCRIPTION
## Summary
- avoid using `innerHTML` when populating attachment list

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ce1de63a88332934b3c43fe282eb8