### PR TITLE
Add waveform creation workflow

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -3,10 +3,11 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Popup</title>
-    <link rel="stylesheet" href="./trello-player.css?1">
+    <link rel="stylesheet" href="./trello-player.css?2">
   </head>
   <body>
     <div id="attachments-container">
+      <div id="waveform-view"></div>
       <audio id="audio-player" controls></audio>
       <div class="controls">
         <button id="prev-button">Previous</button>
@@ -14,8 +15,21 @@
       </div>
       <ul id="attachments-list" class="attachments"></ul>
     </div>
-    
+
+    <div id="waveform-modal" class="hidden" tabindex="0">
+      <div class="modal-content">
+        <p><a id="download-file" href="" download>Step 1: download file</a></p>
+        <p><a href="#" id="load-file">Step 2: load file</a> <input id="waveform-file-input" type="file" accept="audio/*" class="hidden" /></p>
+        <div id="waveform-preview"></div>
+        <div class="modal-actions">
+          <button id="cancel-waveform">Cancel</button>
+          <button id="save-waveform" disabled>Save</button>
+        </div>
+      </div>
+    </div>
+
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
-    <script src="./trello-player-power-up-popup.js?1"></script>
+    <script src="https://unpkg.com/wavesurfer.js@7"></script>
+    <script src="./trello-player-power-up-popup.js?2"></script>
   </body>
 </html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -42,7 +42,7 @@ async function loadPlayer() {
         attachmentsList.appendChild(attachmentLi);
       });
     });
-    
+
     if (m4aAttachments.length > 0) {
       loadAttachment(0);
     }
@@ -61,7 +61,7 @@ function loadAttachment(index) {
     if (playPromise !== undefined) {
       playPromise.then(_ => {}).catch(error => {});
     }
-    
+
     const attachmentsListItems = document.querySelectorAll('#attachments-list li');
     attachmentsListItems.forEach((item, idx) => {
       item.classList.toggle('active', idx === index);

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -3,6 +3,16 @@ let currentAttachmentIndex = 0;
 let m4aAttachments = [];
 let audioPlayer = document.getElementById('audio-player');
 let attachmentsList = document.getElementById('attachments-list');
+let waveformView = document.getElementById('waveform-view');
+let modal = document.getElementById('waveform-modal');
+let downloadLink = document.getElementById('download-file');
+let loadFileLink = document.getElementById('load-file');
+let fileInput = document.getElementById('waveform-file-input');
+let saveBtn = document.getElementById('save-waveform');
+let cancelBtn = document.getElementById('cancel-waveform');
+let waveformPreview = document.getElementById('waveform-preview');
+let wavesurfer;
+let currentAttachment;
 
 async function loadPlayer() {
   try {
@@ -12,12 +22,22 @@ async function loadPlayer() {
     cards.forEach(card => {
       const cardM4aAttachments = card.attachments.filter(attachment => attachment.url.endsWith('.m4a') || attachment.url.endsWith('.mp3'));
       cardM4aAttachments.forEach(attachment => {
-        m4aAttachments.push(attachment);
-        
+        m4aAttachments.push(Object.assign({cardId: card.id}, attachment));
+
         const attachmentLi = document.createElement('li');
-        attachmentLi.innerHTML = attachment.name;
+        const textSpan = document.createElement('span');
+        textSpan.textContent = attachment.name;
+        attachmentLi.appendChild(textSpan);
+        const wrench = document.createElement('span');
+        wrench.textContent = '\uD83D\uDD27';
+        wrench.className = 'wrench';
+        wrench.addEventListener('click', (e) => {
+          e.stopPropagation();
+          openWaveformModal(attachment);
+        });
+        attachmentLi.appendChild(wrench);
         attachmentLi.addEventListener('click', () => {
-          loadAttachment(m4aAttachments.findIndex((att) => att.name == attachment.name));
+          loadAttachment(m4aAttachments.findIndex((att) => att.id == attachment.id));
         });
         attachmentsList.appendChild(attachmentLi);
       });
@@ -46,6 +66,9 @@ function loadAttachment(index) {
     attachmentsListItems.forEach((item, idx) => {
       item.classList.toggle('active', idx === index);
     });
+
+    currentAttachment = m4aAttachments[index];
+    showWaveform(currentAttachment);
   }
 }
 
@@ -60,6 +83,68 @@ document.getElementById('next-button').addEventListener('click', () => {
   if (currentAttachmentIndex < m4aAttachments.length - 1) {
     loadAttachment(currentAttachmentIndex + 1);
   }
+});
+
+function showWaveform(att) {
+  waveformView.innerHTML = '';
+  const wrench = document.createElement('span');
+  wrench.textContent = '\uD83D\uDD27';
+  wrench.className = 'wrench';
+  wrench.addEventListener('click', () => openWaveformModal(att));
+
+  t.get(att.cardId, 'shared', 'waveformData').then(data => {
+    if (data) {
+      const ws = WaveSurfer.create({container: waveformView, interact:false, height:80});
+      ws.loadPeaks(JSON.parse(data), att.url);
+    } else {
+      const msg = document.createElement('span');
+      msg.textContent = 'Waveform is unavailable. Create waveform ';
+      waveformView.appendChild(msg);
+      waveformView.appendChild(wrench);
+    }
+  });
+}
+
+function openWaveformModal(att) {
+  currentAttachment = att;
+  downloadLink.href = att.url;
+  wavesurfer && wavesurfer.destroy();
+  waveformPreview.innerHTML = '';
+  wavesurfer = WaveSurfer.create({container: waveformPreview, height:80});
+  saveBtn.disabled = true;
+  modal.classList.remove('hidden');
+  modal.focus();
+}
+
+loadFileLink.addEventListener('click', (e) => {
+  e.preventDefault();
+  fileInput.click();
+});
+
+fileInput.addEventListener('change', async () => {
+  if (fileInput.files.length === 0) return;
+  const url = URL.createObjectURL(fileInput.files[0]);
+  await wavesurfer.load(url);
+  wavesurfer.once('ready', () => {
+    saveBtn.disabled = false;
+  });
+});
+
+cancelBtn.addEventListener('click', closeModal);
+saveBtn.addEventListener('click', async () => {
+  const peaks = wavesurfer.exportPeaks({channels:1,maxLength:600,precision:1000});
+  await t.set(currentAttachment.cardId, 'shared', 'waveformData', JSON.stringify(peaks));
+  closeModal();
+  showWaveform(currentAttachment);
+});
+
+function closeModal() {
+  modal.classList.add('hidden');
+}
+
+modal.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') { closeModal(); }
+  if (e.key === 'Enter' && !saveBtn.disabled) { saveBtn.click(); }
 });
 
 audioPlayer.addEventListener('ended', () => {

--- a/trello-player-power-up.html
+++ b/trello-player-power-up.html
@@ -3,11 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Connector</title>
-    <link rel="stylesheet" href="./trello-player.css?1">
+    <link rel="stylesheet" href="./trello-player.css?2">
   </head>
   <body>
     <p>This is the HTML connector for the Audio Player for Trello Power-Up. It will be loaded into a hidden iframe when it is enabled.</p>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
-    <script src="./trello-player-power-up.js?3"></script>
+    <script src="https://unpkg.com/wavesurfer.js@7"></script>
+    <script src="./trello-player-power-up.js?4"></script>
   </body>
 </html>

--- a/trello-player.css
+++ b/trello-player.css
@@ -75,3 +75,36 @@ audio {
 #attachments-list {
   overflow-y: auto;
 }
+
+#waveform-view {
+  margin-top: 10px;
+}
+
+.wrench {
+  margin-left: 5px;
+  cursor: pointer;
+}
+
+#waveform-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: grid;
+  place-content: center;
+  z-index: 1000;
+}
+
+#waveform-modal.hidden {
+  display: none;
+}
+
+#waveform-modal .modal-content {
+  background: white;
+  padding: 20px;
+  max-width: 500px;
+}
+
+#waveform-modal .modal-actions {
+  margin-top: 10px;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- integrate WaveSurfer script
- add wrench icon and waveform creation modal
- render waveform preview if available
- bump version query strings for CSS/JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1e97d3083328d3af465763a50b8