### PR TITLE
Fix waveform modal save button

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -30,6 +30,6 @@
 
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up-popup.js?2"></script>
+    <script src="./trello-player-power-up-popup.js?3"></script>
   </body>
 </html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -124,10 +124,10 @@ loadFileLink.addEventListener('click', (e) => {
 fileInput.addEventListener('change', async () => {
   if (fileInput.files.length === 0) return;
   const url = URL.createObjectURL(fileInput.files[0]);
-  await wavesurfer.load(url);
   wavesurfer.once('ready', () => {
     saveBtn.disabled = false;
   });
+  await wavesurfer.load(url);
 });
 
 cancelBtn.addEventListener('click', closeModal);


### PR DESCRIPTION
## Summary
- enable Save button when audio loads in create waveform modal

## Testing
- `node --check trello-player-power-up-popup.js`

------
https://chatgpt.com/codex/tasks/task_e_686ce6f0a34c8332943569696da5d2d4