### PR TITLE
Add wrench overlay for waveform

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Popup</title>
-    <link rel="stylesheet" href="./trello-player.css?3">
+    <link rel="stylesheet" href="./trello-player.css?4">
   </head>
   <body>
     <div id="attachments-container">
@@ -30,6 +30,6 @@
 
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up-popup.js?6"></script>
+    <script src="./trello-player-power-up-popup.js?7"></script>
   </body>
 </html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -87,6 +87,8 @@ function showWaveform(att) {
 
   t.get(att.cardId, 'shared', 'waveformData').then(data => {
     if (data) {
+      wrench.classList.add('floating');
+      waveformView.appendChild(wrench);
       const ws = WaveSurfer.create({
         container: waveformView,
         interact: true,

--- a/trello-player-power-up.html
+++ b/trello-player-power-up.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Connector</title>
-    <link rel="stylesheet" href="./trello-player.css?3">
+    <link rel="stylesheet" href="./trello-player.css?4">
   </head>
   <body>
     <p>This is the HTML connector for the Audio Player for Trello Power-Up. It will be loaded into a hidden iframe when it is enabled.</p>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up.js?5"></script>
+    <script src="./trello-player-power-up.js?6"></script>
   </body>
 </html>

--- a/trello-player.css
+++ b/trello-player.css
@@ -78,11 +78,20 @@ audio {
 
 #waveform-view {
   margin-top: 10px;
+  position: relative;
 }
 
 .wrench {
   margin-left: 5px;
   cursor: pointer;
+}
+
+#waveform-view .wrench.floating {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 0;
+  z-index: 10;
 }
 
 #waveform-modal {


### PR DESCRIPTION
## Summary
- show wrench overlay even when waveform is available
- overlay style for wrench in waveform view
- bump css/js versions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870d01c870c83329b3a13360725d58a