### PR TITLE
Refactor waveform preview component

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -19,8 +19,8 @@
     <template id="waveform-template">
       <span class="no-waveform-msg">Waveform is unavailable. Create waveform </span>
       <span class="wrench">🔧</span>
-      <div class="waveform-canvas"></div>
       <span class="delete-waveform hidden">🅇</span>
+      <div class="waveform-canvas"></div>
     </template>
 
     <template id="attachment-template">

--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -17,7 +17,7 @@
     </div>
 
     <template id="waveform-template">
-      <span class="no-waveform-msg">Waveform is unavailable. Create waveform </span>
+      <span class="no-waveform-msg">Waveform is unavailable.<br />Click on 🔧 to create waveform.</span>
       <span class="wrench">🔧</span>
       <span class="delete-waveform hidden">🅇</span>
       <div class="waveform-canvas"></div>

--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -20,16 +20,13 @@
       <span class="no-waveform-msg">Waveform is unavailable. Create waveform </span>
       <span class="wrench">🔧</span>
       <div class="waveform-canvas"></div>
+      <span class="delete-waveform hidden">🅇</span>
     </template>
 
     <template id="attachment-template">
       <li><span class="attachment-name"></span></li>
     </template>
 
-    <template id="waveform-preview-template">
-      <div class="waveform-canvas"></div>
-      <span class="delete-waveform hidden">🅇</span>
-    </template>
 
     <div id="waveform-modal" class="hidden" tabindex="0">
       <div class="modal-content">
@@ -45,6 +42,6 @@
 
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up-popup.js?10"></script>
+    <script src="./trello-player-power-up-popup.js?11"></script>
   </body>
 </html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -57,8 +57,8 @@ class WaveformPreview extends HTMLElement {
     this.hideMessage();
     this.hideWrench();
   }
-  showDeleteButton() { this.deleteBtn.classList.remove('hidden'); }
-  hideDeleteButton() { this.deleteBtn.classList.add('hidden'); }
+  showDeleteButton() { if (this.deleteBtn) this.deleteBtn.classList.remove('hidden'); }
+  hideDeleteButton() { if (this.deleteBtn) this.deleteBtn.classList.add('hidden'); }
   showMessage() { if (this.msg) this.msg.classList.remove('hidden'); }
   hideMessage() { if (this.msg) this.msg.classList.add('hidden'); }
   showWrench() { if (this.wrench) this.wrench.classList.remove('hidden'); }
@@ -142,11 +142,11 @@ function showWaveform(att) {
   waveformView.innerHTML = '';
   const wf = document.createElement('waveform-preview');
   waveformView.appendChild(wf);
+  wf.showWrench();
   wf.setWrenchHandler(() => openWaveformModal(att));
   t.get(att.cardId, 'shared', 'waveformData').then(data => {
     if (data) {
       wf.hideMessage();
-      wf.wrench.classList.add('floating');
       const wfData = JSON.parse(data);
       wf.loadFromData(wfData.peaks, wfData.duration, {
         interact: true,
@@ -154,7 +154,6 @@ function showWaveform(att) {
       });
     } else {
       wf.showMessage();
-      wf.wrench.classList.remove('floating');
     }
   });
 }

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -6,7 +6,6 @@ let attachmentsList = document.getElementById('attachments-list');
 let waveformView = document.getElementById('waveform-view');
 let waveformTemplate = document.getElementById('waveform-template');
 let attachmentTemplate = document.getElementById('attachment-template');
-let waveformPreviewTemplate = document.getElementById('waveform-preview-template');
 let modal = document.getElementById('waveform-modal');
 let downloadLink = document.getElementById('download-file');
 let loadFileLink = document.getElementById('load-file');
@@ -18,25 +17,31 @@ let deleteWaveform = false;
 class WaveformPreview extends HTMLElement {
   constructor() {
     super();
-    const frag = waveformPreviewTemplate.content.cloneNode(true);
+    const frag = waveformTemplate.content.cloneNode(true);
     this.appendChild(frag);
     this.canvas = this.querySelector('.waveform-canvas');
     this.deleteBtn = this.querySelector('.delete-waveform');
+    this.msg = this.querySelector('.no-waveform-msg');
+    this.wrench = this.querySelector('.wrench');
   }
-  createPlayer() {
+  createPlayer(options = {}) {
     if (this.wavesurfer) {
       this.wavesurfer.destroy();
     }
     this.canvas.innerHTML = '';
-    this.wavesurfer = WaveSurfer.create({container: this.canvas, height:80});
+    this.wavesurfer = WaveSurfer.create(Object.assign({
+      container: this.canvas,
+      height: 80,
+      normalize: true
+    }, options));
     return this.wavesurfer;
   }
-  loadFromData(peaks, duration) {
-    const ws = this.createPlayer();
+  loadFromData(peaks, duration, options = {}) {
+    const ws = this.createPlayer(options);
     ws.load('', peaks, duration);
   }
-  async loadFromUrl(url) {
-    const ws = this.createPlayer();
+  async loadFromUrl(url, options = {}) {
+    const ws = this.createPlayer(options);
     return new Promise((resolve) => {
       ws.once('ready', resolve);
       ws.load(url);
@@ -49,14 +54,23 @@ class WaveformPreview extends HTMLElement {
     }
     this.canvas.innerHTML = '';
     this.hideDeleteButton();
+    this.hideMessage();
+    this.hideWrench();
   }
   showDeleteButton() { this.deleteBtn.classList.remove('hidden'); }
   hideDeleteButton() { this.deleteBtn.classList.add('hidden'); }
+  showMessage() { if (this.msg) this.msg.classList.remove('hidden'); }
+  hideMessage() { if (this.msg) this.msg.classList.add('hidden'); }
+  showWrench() { if (this.wrench) this.wrench.classList.remove('hidden'); }
+  hideWrench() { if (this.wrench) this.wrench.classList.add('hidden'); }
   exportPeaks() {
     return this.wavesurfer.exportPeaks({channels:1,maxLength:600,precision:1000});
   }
   getDuration() {
     return this.wavesurfer.getDuration();
+  }
+  setWrenchHandler(handler) {
+    if (this.wrench) this.wrench.onclick = handler;
   }
 }
 customElements.define('waveform-preview', WaveformPreview);
@@ -126,27 +140,21 @@ document.getElementById('next-button').addEventListener('click', () => {
 
 function showWaveform(att) {
   waveformView.innerHTML = '';
-  const frag = waveformTemplate.content.cloneNode(true);
-  const msg = frag.querySelector('.no-waveform-msg');
-  const wrench = frag.querySelector('.wrench');
-  const canvas = frag.querySelector('.waveform-canvas');
-  wrench.addEventListener('click', () => openWaveformModal(att));
-
-  waveformView.appendChild(frag);
-
+  const wf = document.createElement('waveform-preview');
+  waveformView.appendChild(wf);
+  wf.setWrenchHandler(() => openWaveformModal(att));
   t.get(att.cardId, 'shared', 'waveformData').then(data => {
     if (data) {
-      msg.remove();
-      wrench.classList.add('floating');
-      const ws = WaveSurfer.create({
-        container: canvas,
+      wf.hideMessage();
+      wf.wrench.classList.add('floating');
+      const wfData = JSON.parse(data);
+      wf.loadFromData(wfData.peaks, wfData.duration, {
         interact: true,
-        normalize: true,
-        height:80,
         media: audioPlayer
       });
-      const wfData = JSON.parse(data);
-      ws.load('', wfData.peaks, wfData.duration);
+    } else {
+      wf.showMessage();
+      wf.wrench.classList.remove('floating');
     }
   });
 }
@@ -156,6 +164,8 @@ function openWaveformModal(att) {
   downloadLink.href = att.url;
   downloadLink.download = att.name;
   waveformPreview.clear();
+  waveformPreview.hideMessage();
+  waveformPreview.hideWrench();
   deleteWaveform = false;
   saveBtn.disabled = true;
   modal.classList.remove('hidden');
@@ -168,7 +178,7 @@ function openWaveformModal(att) {
   t.get(att.cardId, 'shared', 'waveformData').then(data => {
     if (data) {
       const wfData = JSON.parse(data);
-      waveformPreview.loadFromData(wfData.peaks, wfData.duration);
+      waveformPreview.loadFromData(wfData.peaks, wfData.duration, {interact:false});
       waveformPreview.showDeleteButton();
     } else {
       waveformPreview.hideDeleteButton();
@@ -184,7 +194,7 @@ loadFileLink.addEventListener('click', (e) => {
 fileInput.addEventListener('change', async () => {
   if (fileInput.files.length === 0) return;
   const url = URL.createObjectURL(fileInput.files[0]);
-  await waveformPreview.loadFromUrl(url);
+  await waveformPreview.loadFromUrl(url, {interact:false});
   saveBtn.disabled = false;
   deleteWaveform = false;
   waveformPreview.hideDeleteButton();


### PR DESCRIPTION
## Summary
- merge waveform templates and add delete icon in shared template
- extend `<waveform-preview>` so the player and modal share logic
- update player to use `<waveform-preview>` element
- bump popup script version

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878d63313b4833280726bfbb642039d