### PR TITLE
Fix theme link color and update cache busting

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trello Player</title>
     <link rel="icon" type="image/png" href="./trello-player-192.png">
-    <link rel="stylesheet" href="./trello-player.css">
+    <link rel="stylesheet" href="./trello-player.css?12">
 </head>
 <body>
     <h1 id="list-name">Trello Player Power-up Privacy</h1>

--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Popup</title>
-    <link rel="stylesheet" href="./trello-player.css?11">
+    <link rel="stylesheet" href="./trello-player.css?12">
   </head>
   <body>
     <div id="attachments-container">

--- a/trello-player-power-up.html
+++ b/trello-player-power-up.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Connector</title>
-    <link rel="stylesheet" href="./trello-player.css?11">
+    <link rel="stylesheet" href="./trello-player.css?12">
   </head>
   <body>
     <p>This is the HTML connector for the Audio Player for Trello Power-Up. It will be loaded into a hidden iframe when it is enabled.</p>

--- a/trello-player.css
+++ b/trello-player.css
@@ -48,7 +48,7 @@ body {
   display: none;
 }
 a {
-  color: YellowGreen;
+  color: var(--link-color);
   text-decoration: none;
 }
 a:hover {


### PR DESCRIPTION
## Summary
- keep link styling theme-aware using `var(--link-color)`
- bump CSS asset version to 12 across pages
- add cache busting to `privacy.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5ffc9b508332a743f4d76158f757