### PR TITLE
Fix auth URL for Trello authorization

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -49,6 +49,6 @@
 
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up-popup.js?24"></script>
+    <script src="./trello-player-power-up-popup.js?25"></script>
   </body>
 </html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -288,12 +288,18 @@ audioPlayer.addEventListener('ended', () => {
 authorizeBtn.addEventListener('click', async () => {
   const key = apiKeyInput.value.trim();
   await t.set('board', 'private', 'apikey', key);
-  t.authorize({
-    callback_method: 'fragment',
-    return_url: window.location.href.split('#')[0],
-    scope: 'read',
-    expiration: 'never'
-  });
+  const returnUrl = window.location.href.split('#')[0];
+  const authUrl =
+    'https://trello.com/1/authorize?expiration=never' +
+    '&scope=read&key=' + encodeURIComponent(key) +
+    '&callback_method=fragment' +
+    '&return_url=' + encodeURIComponent(returnUrl);
+
+  t.authorize(authUrl, {
+    height: 680,
+    width: 500,
+    persist: true
+  }).then(() => t.closePopup());
 });
 
 apiKeyInput.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- construct `authUrl` for Trello auth with API key and return URL
- pass auth URL into `t.authorize` and close popup after authorization
- bump cachebuster on popup JS

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b26d698d483329ff135c8a8d56895