### PR TITLE
Refactor authorization flow

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -49,6 +49,6 @@
 
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="./trello-player-power-up-popup.js?26"></script>
+    <script src="./trello-player-power-up-popup.js?27"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor `t.authorize` usage
- store auth popup handle and validate token
- reload window after storing token
- bump asset version number

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7915b4888332a0bf4ac94d42cd10